### PR TITLE
fix webrtc dependency bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,11 +323,16 @@ You can send commands and receive results in any of these languages:
 
 ## 6. **[WebRTC video streaming](https://github.com/xrdevrob/QuestCameraKit?tab=readme-ov-file#-webrtc-video-streaming)**
 
+- Open the `Package Manager`, click on the + sign in the upper left/right corner.
+	- Select "Add package from git URL".
+	- Enter URL: https://github.com/endel/NativeWebSocket.git#upm and click in Install.
+	- After the installation finished, click on the + sign in the upper left/right corner again.
+	- Enter URL https://github.com/FireDragonGameStudio/SimpleWebRTC.git?path=/Assets/SimpleWebRTC#upm and click on Install
 - Open the `WebcamToWebRTC` scene.
 - Link up your signaling server on the `Client-STUNConnection` component in the `Web Socket Server Address` field.
 - Build and deploy the `WebRTC-Quest` scene to your Quest3 device.
 - Open the `WebRTC-SingleClient` scene on your Editor.
-- Build and deploy the `WebRTC-SingleClient` scene on another device or start it the Unity Editor. More information can be found [here](https://www.youtube.com/watch?v=-CwJTgt_Z3M)
+- Build and deploy the `WebRTC-SingleClient` scene to another device or start it from within the Unity Editor. More information can be found [here](https://www.youtube.com/watch?v=-CwJTgt_Z3M)
 - Start the WebRTC app on your Quest and on your other devices. Quest and client streaming devices should connect automatically to the websocket signaling server.
 - Perform the Start gesture with your left hand, or press the menu button on your left controller to start streaming from Quest3 to your WebRTC client app.
 
@@ -338,6 +343,7 @@ You can send commands and receive results in any of these languages:
 	- Enter URL: https://github.com/endel/NativeWebSocket.git#upm and click in Install.
 	- After the installation finished, click on the + sign in the upper left/right corner again.
 	- Enter URL https://github.com/FireDragonGameStudio/SimpleWebRTC.git?path=/Assets/SimpleWebRTC#upm and click on Install
+	- Use the menu `Tools/Update WebRTC Define Symbol` to update the scripting define symbols if needed.
 - Make sure your own websocket signaling server is up and running. You can find more information about the necessary steps [here](https://youtu.be/-CwJTgt_Z3M?t=1458).
 - If you're going to stream over LAN, make sure the `STUN Server Address` field on `[BuildingBlock] Camera Rig/TrackingSpace/CenterEyeAnchor/Client-STUNConnection` is empty, otherwise leave the default value.
 - Make sure to enable the `Web Socket Connection active` flag on `[BuildingBlock] Camera Rig/TrackingSpace/CenterEyeAnchor/Client-STUNConnection` to connect to the websocket server automatically on start.

--- a/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/Editor.meta
+++ b/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38a1f69d8a049aa49942b387ba6b266d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/Editor/WebRTCDefineSymbolChecker.cs
+++ b/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/Editor/WebRTCDefineSymbolChecker.cs
@@ -1,0 +1,58 @@
+#if UNITY_EDITOR
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEngine;
+
+[InitializeOnLoad]
+public static class WebRTCDefineSymbolChecker {
+    static WebRTCDefineSymbolChecker() {
+        EditorApplication.delayCall += UpdateWebRTCDefine;
+    }
+
+    [MenuItem("Tools/Update WebRTC Define Symbol")]
+    public static void UpdateWebRTCDefine() {
+        var hasWebRTC = HasWebRTCPackage();
+
+        var targets = new[]
+        {
+            NamedBuildTarget.Standalone,
+            NamedBuildTarget.Android,
+            NamedBuildTarget.iOS,
+        };
+
+        foreach (var target in targets) {
+            try {
+                var defines = PlayerSettings.GetScriptingDefineSymbols(target);
+                var defineList = defines.Split(';')
+                                        .Select(s => s.Trim())
+                                        .Where(s => !string.IsNullOrEmpty(s))
+                                        .ToList();
+
+                var symbolExists = defineList.Contains("WEBRTC_ENABLED");
+
+                switch (hasWebRTC) {
+                    case true when !symbolExists:
+                        defineList.Add("WEBRTC_ENABLED");
+                        Debug.Log($"[WebRTCDefineSymbolChecker] Added WEBRTC_ENABLED for {target}");
+                        break;
+                    case false when symbolExists:
+                        defineList.Remove("WEBRTC_ENABLED");
+                        Debug.Log($"[WebRTCDefineSymbolChecker] Removed WEBRTC_ENABLED for {target}");
+                        break;
+                }
+
+                var newDefines = string.Join(";", defineList);
+                PlayerSettings.SetScriptingDefineSymbols(target, newDefines);
+            } catch (System.Exception ex) {
+                Debug.LogWarning($"[WebRTCDefineSymbolChecker] Could not update define for target {target}: {ex.Message}");
+            }
+        }
+    }
+
+    private static bool HasWebRTCPackage() {
+        var packages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
+        return packages.Where(p => p.name.Equals("com.unity.webrtc")).Any();
+    }
+}
+#endif

--- a/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/Editor/WebRTCDefineSymbolChecker.cs.meta
+++ b/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/Editor/WebRTCDefineSymbolChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4e5bdf08073cd58458b8c8574c6e6767

--- a/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/WebRTCController.cs
+++ b/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/Scripts/WebRTCController.cs
@@ -1,29 +1,34 @@
 using PassthroughCameraSamples;
+#if WEBRTC_ENABLED
 using SimpleWebRTC;
+#endif
 using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace QuestCameraKit.WebRTC {
     public class WebRTCController : MonoBehaviour {
-
         [SerializeField] private WebCamTextureManager passthroughCameraManager;
         [SerializeField] private RawImage canvasRawImage;
-        [SerializeField] private WebRTCConnection webRTCConnection;
+        [SerializeField] private GameObject connectionGameObject;
 
+#if WEBRTC_ENABLED
         private WebCamTexture _webcamTexture;
+        private WebRTCConnection _webRTCConnection;
 
         private IEnumerator Start() {
             yield return new WaitUntil(() => passthroughCameraManager.WebCamTexture != null && passthroughCameraManager.WebCamTexture.isPlaying);
 
+            _webRTCConnection = connectionGameObject.GetComponent<WebRTCConnection>();
             _webcamTexture = passthroughCameraManager.WebCamTexture;
             canvasRawImage.texture = _webcamTexture;
         }
 
         private void Update() {
             if (OVRInput.Get(OVRInput.Button.Start)) {
-                webRTCConnection.StartVideoTransmission();
+                _webRTCConnection.StartVideoTransmission();
             }
         }
+#endif
     }
 }

--- a/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/WebRTC-Quest.unity
+++ b/Unity-QuestVisionKit/Assets/Samples/6 WebRTC/WebRTC-Quest.unity
@@ -2127,7 +2127,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   passthroughCameraManager: {fileID: 1436385067}
   canvasRawImage: {fileID: 557677174}
-  webRTCConnection: {fileID: 6985653293374303736}
+  connectionGameObject: {fileID: 805715864782633738}
 --- !u!1 &1883890013
 GameObject:
   m_ObjectHideFlags: 0

--- a/Unity-QuestVisionKit/Packages/manifest.json
+++ b/Unity-QuestVisionKit/Packages/manifest.json
@@ -1,7 +1,5 @@
 {
   "dependencies": {
-    "com.endel.nativewebsocket": "https://github.com/endel/NativeWebSocket.git#upm",
-    "com.firedragongamestudio.simplewebrtc": "https://github.com/FireDragonGameStudio/SimpleWebRTC.git?path=/Assets/SimpleWebRTC#upm",
     "com.meta.xr.mrutilitykit": "72.0.0",
     "com.meta.xr.sdk.core": "72.0.0",
     "com.unity.ide.rider": "3.0.34",

--- a/Unity-QuestVisionKit/Packages/packages-lock.json
+++ b/Unity-QuestVisionKit/Packages/packages-lock.json
@@ -1,22 +1,5 @@
 {
   "dependencies": {
-    "com.endel.nativewebsocket": {
-      "version": "https://github.com/endel/NativeWebSocket.git#upm",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "1d8b49b3fee41c09a98141f1f1a5e4db47e14229"
-    },
-    "com.firedragongamestudio.simplewebrtc": {
-      "version": "https://github.com/FireDragonGameStudio/SimpleWebRTC.git?path=/Assets/SimpleWebRTC#upm",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {
-        "com.unity.webrtc": "3.0.0-pre.8",
-        "com.unity.textmeshpro": "3.0.6"
-      },
-      "hash": "1bdf496d4b9ad574c83691a3cb960e16065508ae"
-    },
     "com.meta.xr.mrutilitykit": {
       "version": "72.0.0",
       "depth": 0,
@@ -65,13 +48,6 @@
         "com.unity.nuget.mono-cecil": "1.11.4",
         "com.unity.test-framework.performance": "3.0.3"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.editorcoroutines": {
-      "version": "1.0.0",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
@@ -243,17 +219,6 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0"
       }
-    },
-    "com.unity.webrtc": {
-      "version": "3.0.0-pre.8",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.audio": "1.0.0",
-        "com.unity.editorcoroutines": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
     },
     "com.unity.xr.legacyinputhelpers": {
       "version": "2.1.12",


### PR DESCRIPTION
see bug #6.

PR removes all dependencies for WebRTC and WebSockets. User interested in using this features, will have to add these packages themselves, similar to QRCode tracking and detection. Updated docs accordingly and added a Scripting Define Symbol called WEBRTC_ENABLED to have conditionals for building and WebRTC scripts.