### PR TITLE
fix(#34): Uses type check instead of filename for zXing existence check

### DIFF
--- a/Unity-QuestVisionKit/Assets/Samples/3 QRCodeTracking/Scripts/Editor/ZXingDefineSymbolChecker.cs
+++ b/Unity-QuestVisionKit/Assets/Samples/3 QRCodeTracking/Scripts/Editor/ZXingDefineSymbolChecker.cs
@@ -1,8 +1,8 @@
 #if UNITY_EDITOR
+using System;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEngine;
-using System.IO;
 using System.Linq;
 
 [InitializeOnLoad]
@@ -61,9 +61,13 @@ public static class ZXingDefineSymbolChecker
 
     private static bool HasZXingDLL()
     {
-        var files = Directory.GetFiles(Application.dataPath, "*ZXing.dll", SearchOption.AllDirectories)
-                             .Concat(Directory.GetFiles(Application.dataPath, "*zxing.dll", SearchOption.AllDirectories));
-        return files.Any();
+        const string typeName = "ZXing.QrCode.QRCodeReader";
+
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (asm.GetType(typeName, throwOnError: false) != null) return true;
+        }
+        return false;
     }
 }
 #endif

--- a/Unity-QuestVisionKit/Assets/Samples/3 QRCodeTracking/Scripts/QrCodeDisplayManager.cs
+++ b/Unity-QuestVisionKit/Assets/Samples/3 QRCodeTracking/Scripts/QrCodeDisplayManager.cs
@@ -57,7 +57,6 @@ public class QrCodeDisplayManager : MonoBehaviour
 
         CleanupInactiveMarkers();
     }
-#endif
 
     private static Vector2 ToViewport(Vector2 uv) => new(Mathf.Clamp01(uv.x), Mathf.Clamp01(uv.y));
 
@@ -224,4 +223,5 @@ public class QrCodeDisplayManager : MonoBehaviour
             _activeMarkers.Remove(key);
         }
     }
+#endif
 }

--- a/Unity-QuestVisionKit/ProjectSettings/ProjectSettings.asset
+++ b/Unity-QuestVisionKit/ProjectSettings/ProjectSettings.asset
@@ -844,7 +844,7 @@ PlayerSettings:
   webWasm2023: 0
   webEnableSubmoduleStrippingCompatibility: 0
   scriptingDefineSymbols:
-    Android: ISDK_OPENXR_HAND;USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS;ZXING_ENABLED
+    Android: ISDK_OPENXR_HAND;USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS
     EmbeddedLinux: 
     GameCoreScarlett: 
     GameCoreXboxOne: 
@@ -854,11 +854,11 @@ PlayerSettings:
     PS5: 
     QNX: 
     ReservedCFE: 
-    Standalone: ISDK_OPENXR_HAND;USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS;ZXING_ENABLED
+    Standalone: ISDK_OPENXR_HAND;USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS
     VisionOS: 
     Windows Store Apps: USE_INPUT_SYSTEM_POSE_CONTROL;USE_STICK_CONTROL_THUMBSTICKS
     XboxOne: 
-    iPhone: ZXING_ENABLED
+    iPhone: 
     tvOS: 
   additionalCompilerArguments: {}
   platformArchitecture: {}


### PR DESCRIPTION
Fixes https://github.com/xrdevrob/QuestCameraKit/issues/34

- Check zXing existence by type instead of file name

- Also properly wraps remaining methods in `QrCodeDisplayManager`
- Also removes `ZXING_ENABLED` by default